### PR TITLE
mapped etc2 types correctly, fixed ktx with etc2 texture opening issue

### DIFF
--- a/DxImageLoader/compress_interface.cpp
+++ b/DxImageLoader/compress_interface.cpp
@@ -201,14 +201,18 @@ CMP_FORMAT get_cmp_format(gli::format format, ExFormatInfo& exInfo, bool isSourc
 		return CMP_FORMAT_ETC2_RGB;
 	case gli::format::FORMAT_RGBA_ETC2_SRGB_BLOCK8:
 		if (isSource) exInfo.swizzleRGB = true;
-		return CMP_FORMAT_ETC2_SRGBA;
+		return CMP_FORMAT_ETC2_SRGBA1;
 	case gli::format::FORMAT_RGBA_ETC2_UNORM_BLOCK8:
 		if (isSource) exInfo.swizzleRGB = true;
-		return CMP_FORMAT_ETC2_RGBA;
+		return CMP_FORMAT_ETC2_RGBA1;
 
 	case gli::format::FORMAT_RGBA_ETC2_SRGB_BLOCK16:
+		if (isSource) exInfo.swizzleRGB = true;
+		return CMP_FORMAT_ETC2_SRGBA;
 	case gli::format::FORMAT_RGBA_ETC2_UNORM_BLOCK16:
-		throw std::runtime_error("ETC2 Block16 formats are not supported");
+		if (isSource) exInfo.swizzleRGB = true;
+		return CMP_FORMAT_ETC2_RGBA;
+		
 
 	case gli::format::FORMAT_R_EAC_UNORM_BLOCK8:
 	case gli::format::FORMAT_R_EAC_SNORM_BLOCK8:


### PR DESCRIPTION
references: https://registry.khronos.org/OpenGL-Refpages/es3.1/html/glCompressedTexImage2D.xhtml

FORMAT_RGBA_ETC2_SRGB_BLOCK8 should map to CMP_FORMAT_ETC2_SRGBA1 (block 8)
FORMAT_RGBA_ETC2_SRGB_BLOCK16 shoudl map to CMP_FORMAT_ETC2_SRGBA (block 16)

texture for test: 
[etc2.zip](https://github.com/kopaka1822/ImageViewer/files/14834681/etc2.zip)
